### PR TITLE
Fix build failing by explicitly setting libdir

### DIFF
--- a/io.github.stsdc.gadget_clock.json
+++ b/io.github.stsdc.gadget_clock.json
@@ -9,7 +9,7 @@
         "--socket=fallback-x11",
         "--socket=wayland",
         "--device=dri"
-        ],
+    ],
     "cleanup" : [
         "/include",
         "/lib/pkgconfig",
@@ -32,13 +32,11 @@
                     "path": ".",
                     "type": "dir"
                 }
-            ],
-            "config-opts" : [
-                "--libdir=lib"
             ]
         }
     ],
     "build-options" : {
+        "libdir": "/app/lib",
         "env" : {        }
     }
 }


### PR DESCRIPTION
The following build error causes because:

- sigc++ is installed under `/app/lib64` not `/app/lib` on x64_64 systems, where is not searched as a library directory
- glibmm tries to clone sigc++ as not found
- but internet access during build process is not allowed by default on Flatpak so cloning sigc++ fails

This PR fixes the above issue by explicitly setting libdir to `/app/lib` even on x86_64 systems.

```
========================================================================
Building module glibmm in /__w/appcenter-reviews/appcenter-reviews/.flatpak-builder/build/glibmm-1
========================================================================
Cloning into 'libsigcplusplus'...
fatal: unable to access 'https://github.com/libsigcplusplus/libsigcplusplus.git/': Could not resolve host: github.com
The Meson build system
Version: 1.5.2
Source dir: /run/build/glibmm
Build dir: /run/build/glibmm/_flatpak_build
Build type: native build
Project name: glibmm
Project version: 2.84.0
C++ compiler for the host machine: ccache c++ (gcc 14.2.0 "c++ (GCC) 14.2.0")
C++ linker for the host machine: c++ ld.bfd 2.44
Host machine cpu family: x86_64
Host machine cpu: x86_64
Program python3 found: YES 3.12.10 3.12.10 (/usr/bin/python3)
Found pkg-config: YES (/usr/bin/pkg-config) 2.4.3
Found CMake: /usr/bin/cmake (3.31.7)
Run-time dependency sigc++-3.0 found: NO (tried pkgconfig and cmake)
Looking for a fallback subproject for the dependency sigc++-3.0

../meson.build:131:13: ERROR: Git command failed: ['/usr/bin/git', '-c', 'advice.detachedHead=false', 'clone', '--depth', '1', '--branch', 'master', 'https://github.com/libsigcplusplus/libsigcplusplus.git', 'libsigcplusplus']

A full log can be found at /run/build/glibmm/_flatpak_build/meson-logs/meson-log.txt
Error: module glibmm: Child process exited with code 1
```
