### PR TITLE
Prevent window from being resized

### DIFF
--- a/src/clock.cpp
+++ b/src/clock.cpp
@@ -6,6 +6,7 @@ GadgetClock::GadgetClock() {
   set_title("DrawingArea");
   set_default_size(200, 200);
   set_decorated(false);
+  set_resizable(false);
 
   auto provider = Gtk::CssProvider::create();
   provider->load_from_resource("/com/github/stsdc/gadget_clock/styles/main.css");


### PR DESCRIPTION
Currently it's possible to resize the window by using right-click menu or using the "maximize window" shortcut, despite window not being decorated.

Before/after.

<img width="333" height="445" alt="Screenshot from 2025-07-27 23 41 42" src="https://github.com/user-attachments/assets/847a3d09-b283-4c71-a07b-11434318f87f" />
<img width="323" height="361" alt="Screenshot from 2025-07-27 23 41 03" src="https://github.com/user-attachments/assets/81a5fe42-ed07-4575-aaf2-58f5f125f127" />
